### PR TITLE
Fixed ScProcess return type and frame rate limiter precision issue

### DIFF
--- a/LOMNHook/LOMNAPI/ScProcess.h
+++ b/LOMNHook/LOMNAPI/ScProcess.h
@@ -5,7 +5,7 @@ struct ScProcess;
 // ScProcess Vtable
 typedef void* (__thiscall *ScProcess__VectorDeletingDestructor)(void*, int);
 typedef void(__thiscall *SxReferenceCountable__Free)(void);
-typedef void(__thiscall ScProcess::*ScProcess__Process)(double, double);
+typedef char(__thiscall ScProcess::*ScProcess__Process)(double, double);
 struct ScProcess__vtbl {
 	ScProcess__VectorDeletingDestructor _destructor;
 	SxReferenceCountable__Free _referenceCountableFree;

--- a/LOMNHook/Mods/FrameThrottle.cpp
+++ b/LOMNHook/Mods/FrameThrottle.cpp
@@ -8,11 +8,11 @@ FrameThrottle::FrameThrottle() : ScProcess() {
 	QueryPerformanceFrequency(&TicksPerSecond);
 }
 
-void FrameThrottle::Process(double time, double deltaTime) {
+char FrameThrottle::Process(double time, double deltaTime) {
 	LARGE_INTEGER value;
 	QueryPerformanceCounter(&value);
 	if (this->LastCounterValue != 0) {
-		long long target = this->LastCounterValue + this->TargetFrameTime * TicksPerSecond.QuadPart;
+		long long target = this->LastCounterValue + TicksPerSecond.QuadPart / TargetFPS;
 
 		//long long delta = target - value.QuadPart;
 		//OutputDebugStringW(std::to_wstring(delta).c_str());
@@ -25,4 +25,5 @@ void FrameThrottle::Process(double time, double deltaTime) {
 	}
 	this->LastCounterValue = value.QuadPart;
 	//OutputDebugStringW(L"Frame Throttle!\n");
+	return 1;
 }

--- a/LOMNHook/Mods/FrameThrottle.h
+++ b/LOMNHook/Mods/FrameThrottle.h
@@ -6,7 +6,7 @@ struct FrameThrottle : ScProcess {
 public:
 	FrameThrottle();
 	char Process(double time, double deltaTime);
-	float TargetFPS = 60;
+	int TargetFPS = 60;
 	float TargetFrameTime = 1.0f / (float)TargetFPS;
 	bool Enabled = true;
 

--- a/LOMNHook/Mods/FrameThrottle.h
+++ b/LOMNHook/Mods/FrameThrottle.h
@@ -5,8 +5,9 @@
 struct FrameThrottle : ScProcess {
 public:
 	FrameThrottle();
-	void Process(double time, double deltaTime);
-	float TargetFrameTime = 1.0f / 60.0f;
+	char Process(double time, double deltaTime);
+	float TargetFPS = 60;
+	float TargetFrameTime = 1.0f / (float)TargetFPS;
 	bool Enabled = true;
 
 private:


### PR DESCRIPTION
The issue appears to have been a combination of not returning 1 and slightly inaccurate floating point math.